### PR TITLE
Enhance inheritability of APIClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,27 @@ Delete url (fetch etag automatically in advance):
 ```python
 res_delete = api.delete_auto_etag("<url>")
 ```
+
+## Custom example
+
+Subclass `APIClient` to create custom api client:
+
+```python
+def sign(url):
+    """some function return signature"""
+    ...
+    return <signed url>
+
+class CustomAPIClient(APIClient):
+    """custom api client"""
+
+    def auth_headers(self, f: Callable) -> Callable:
+        """custom auth headers"""
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            headers = kwargs.get("headers", {}).copy()
+            url = args[0]
+            headers.update({"Signature": sign(url)})
+            kwargs["headers"] = headers
+            return f(*args, **kwargs)
+```

--- a/restful_client_lite/__init__.py
+++ b/restful_client_lite/__init__.py
@@ -105,11 +105,11 @@ class APIClient(object):
         )
 
     def patch(
-        self, url: str, etag: str, data: Union[List, Dict] = {}, headers: Dict = {}
+        self, url: str, etag: str = "", data: Union[List, Dict] = {}, headers: Dict = {}
     ) -> requests.Response:
         """method patch"""
         return self.method_with_etag(
-            url, etag, data=data, headers=headers, method="patch"
+            url, etag=etag, data=data, headers=headers, method="patch"
         )
 
     def patch_auto_etag(
@@ -119,11 +119,11 @@ class APIClient(object):
         return self.method_auto_etag(url, data=data, headers=headers, method="patch")
 
     def delete(
-        self, url: str, etag: str, data: Union[List, Dict] = {}, headers: Dict = {}
+        self, url: str, etag: str = "", data: Union[List, Dict] = {}, headers: Dict = {}
     ) -> requests.Response:
         """method delete"""
         return self.method_with_etag(
-            url, etag, data=data, headers=headers, method="delete"
+            url, etag=etag, data=data, headers=headers, method="delete"
         )
 
     def delete_auto_etag(

--- a/restful_client_lite/tests/__init__.py
+++ b/restful_client_lite/tests/__init__.py
@@ -1,0 +1,37 @@
+import unittest
+from restful_client_lite import APIClient
+import os
+import random
+
+
+def generate_random_key(l):
+    return ("%0" + str(l) + "x") % random.randrange(16 ** l)
+
+
+STANDARD_ROLES = {
+    "roles": [
+        {"resources": ["tokens"], "role": "user"},
+        {"resources": ["scores"], "role": "author"},
+    ]
+}
+
+
+class ClientTestBase(unittest.TestCase):
+    def setUp(self):
+        self.api_root = os.environ.get("API_ROOT", "http://127.0.0.1:5000")
+        self.token_author = os.environ.get("TOKEN_AUTHOR", "")
+        self.manager = APIClient(self.api_root, {"token": self.token_author})
+        self.auth = {
+            "name": generate_random_key(6),
+            "token": generate_random_key(16),
+            "roles": STANDARD_ROLES["roles"],
+        }
+        res_post_json = self.manager.post("/tokens", data=self.auth).json()
+        self.auth.update(res_post_json)
+        self.api = APIClient(self.api_root, {"token": self.auth["token"]})
+
+    def tearDown(self):
+        self.api.delete("/scores", etag="")
+        self.manager.delete(
+            "/tokens/" + self.auth["_id"], etag=self.auth["_etag"], data={}
+        )

--- a/restful_client_lite/tests/test_inherit.py
+++ b/restful_client_lite/tests/test_inherit.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+from restful_client_lite import APIClient
+from restful_client_lite.tests import ClientTestBase
+from typing import Dict, Callable
+import requests
+from urllib.parse import urljoin
+from functools import wraps
+
+
+class CustomAPIClient(APIClient):
+    """custom api client"""
+
+    def __init__(self, api_root, auth: Dict[str, str]) -> None:
+        super(CustomAPIClient, self).__init__(api_root, auth)
+        # store side effects by custom methods
+        self.custom = {}
+        # change wrapper sequence
+        self.get = self.abs_url(self.auth_headers(self.get_inner))
+
+    def abs_url(self, f: Callable) -> Callable:
+        @wraps(f)
+        def wrapper(url, *args, **kwargs):
+            self.custom["abs_url"] = "custom"
+            return f(urljoin(self.api_root, url), *args, **kwargs)
+
+        return wrapper
+
+    def auth_headers(self, f: Callable) -> Callable:
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            self.custom["url"] = args[0]
+            self.custom["auth_headers"] = "custom"
+            headers = kwargs.get("headers", {}).copy()
+            headers.update({"Authorization": self.get_authorization_header()})
+            kwargs["headers"] = headers
+            return f(*args, **kwargs)
+
+        return wrapper
+
+    def get_inner(self, url: str, headers: Dict = {}) -> requests.Response:
+        """method GET"""
+        self.custom["get"] = "custom"
+        return requests.get(url, headers=headers)
+
+
+class InheritageTestCase(ClientTestBase):
+    def test_custom_client(self):
+        # use custom api
+        self.api = CustomAPIClient(self.api_root, {"token": self.auth["token"]})
+        url = "/scores"
+        # check custom wrapper and method applied
+        self.api.get("/scores")
+        for i in ["get", "abs_url", "auth_headers"]:
+            self.assertEqual(self.api.custom.get(i), "custom")
+        self.assertNotEqual(self.api.custom.get("url"), url)

--- a/restful_client_lite/tests/test_methods.py
+++ b/restful_client_lite/tests/test_methods.py
@@ -1,43 +1,10 @@
 # -*- coding: utf-8 -*-
 
-import unittest
-from restful_client_lite import APIClient
-import os
+from restful_client_lite.tests import ClientTestBase, generate_random_key
 import random
 
 
-def generate_random_key(l):
-    return ("%0" + str(l) + "x") % random.randrange(16 ** l)
-
-
-STANDARD_ROLES = {
-    "roles": [
-        {"resources": ["tokens"], "role": "user"},
-        {"resources": ["scores"], "role": "author"},
-    ]
-}
-
-
-class ClientTestBase(unittest.TestCase):
-    def setUp(self):
-        self.api_root = os.environ.get("API_ROOT", "http://127.0.0.1:5000")
-        self.token_author = os.environ.get("TOKEN_AUTHOR", "")
-        self.manager = APIClient(self.api_root, {"token": self.token_author})
-        self.auth = {
-            "name": generate_random_key(6),
-            "token": generate_random_key(16),
-            "roles": STANDARD_ROLES["roles"],
-        }
-        res_post_json = self.manager.post("/tokens", data=self.auth).json()
-        self.auth.update(res_post_json)
-        self.api = APIClient(self.api_root, {"token": self.auth["token"]})
-
-    def tearDown(self):
-        self.api.delete("/scores", etag="")
-        self.manager.delete(
-            "/tokens/" + self.auth["_id"], etag=self.auth["_etag"], data={}
-        )
-
+class MethodsTestCase(ClientTestBase):
     def test_can_post(self):
         doc = {"name": generate_random_key(6), "score": random.randint(60, 100)}
         res = self.api.post("/scores", data=doc)


### PR DESCRIPTION
* Issue: decorators defined in class are not inheritable
* Fix: apply wrappers in `__init__` instead of decorators